### PR TITLE
function to send usb midi data to er-301 over i2c

### DIFF
--- a/firmware/Sweet_3/Sweet_3.ino
+++ b/firmware/Sweet_3/Sweet_3.ino
@@ -73,6 +73,13 @@ int midiDirty = 0;
 const int midiFlashDuration = 50;
 int ledPin = 13;
 
+// midi read helpers
+#define MIDI_CANNEL_OFFSET 20
+int command = 0;
+int channel = 0;
+int data1 = 0;
+int data2 = 0;
+
 // the storage of the values; current is in the main loop; last value is for midi output
 int volatile currentValue[channelCount];
 int lastMidiValue[channelCount];
@@ -454,9 +461,40 @@ void readMidi()
  */
 
 void doMidiRead()
-{
+{  
   MIDI.read();
   usbMIDI.read();
+  
+  if(er301Present) {
+    
+    int acommand = usbMIDI.getType();
+    int achannel = usbMIDI.getChannel()-1+MIDI_CANNEL_OFFSET;
+    int adata1   = usbMIDI.getData1();
+    int adata2   = usbMIDI.getData2();
+     
+    if (command != acommand || channel != achannel || data1 != adata1 || data2 != adata2) {
+      
+      command = acommand;
+      channel = achannel;
+      data1 = adata1;
+      data2 = adata2;
+  
+      switch(command){
+        case 128:
+           D(Serial.printf("do midi read %d %d %d %d\n", command, channel, data1, data2));
+           sendi2c(er301I2Caddress, 0, TO_TR, channel, 0);
+           break;
+        case 144:
+           D(Serial.printf("do midi read %d %d %d %d\n", command, channel, data1, data2));
+           sendi2c(er301I2Caddress, 0, TO_TR, channel, 1);
+           // data1 == c-2 == data1-21 = A0 
+           sendi2c(er301I2Caddress, 0, TO_CV, channel, (data1 - 21) * 136.5416);
+           break;
+      }
+      
+    }
+  }
+  
 }
 
 /*


### PR DESCRIPTION
Implement function so send midi data receved from usb midi in to er-301 over i2c.  Midi channel 1-16 is mapped to ic2 channel 20-25 and gets midi cv as pitch and gate.